### PR TITLE
New work item: crate `r2c2_iri`

### DIFF
--- a/.github/CODEOWNER
+++ b/.github/CODEOWNER
@@ -9,5 +9,8 @@
 # Owners of the /dummy work-item
 /dummy  @pchampin @Tpt # ...
 
+# Owners of the /iri work-item
+/iri    @pchampin
+
 # Owners of another work item
 # ...

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -2,6 +2,7 @@
 
 members = [
   "dummy",
+  "iri",
 ]
 resolver = "3"
 

--- a/iri/Cargo.toml
+++ b/iri/Cargo.toml
@@ -1,0 +1,14 @@
+[package]
+name = "r2c2_iri"
+version.workspace = true
+authors.workspace = true
+edition.workspace = true
+repository.workspace = true
+readme.workspace = true
+license-file.workspace = true
+keywords.workspace = true
+
+[dependencies]
+
+[lints]
+workspace = true

--- a/iri/src/lib.rs
+++ b/iri/src/lib.rs
@@ -1,0 +1,4 @@
+//! TODO: define types and traits for handling IRIs.
+
+#[cfg(test)]
+mod tests {}


### PR DESCRIPTION
**This is a proposal for new work item.** Please provide feedback (as PR reviews, comments or :+1:/:-1:) by 2025-03-31

This "utility" crate is meant to provide:
* lightweight types wrapping `str` with the guarantee that it is a valid IRI / IRI reference
* MAYBE a type allowing to resolve multiple relative IRI references against a fixed base IRI (although it is maybe better to leave this to specific implementations)

I have [published an analysis](https://github.com/pchampin/bench_iri) of 4 similar crates (including my own, [sophia_iri]), and came up with a number of lessons learned, in order to inform the design choices of `r2c2_iri`. Full disclosure, the conclusions lean toward the design choices of [sophia_iri] -- in fact, I had performed a preliminary version of this analysis while working on Sophia, so this is not a coincidence.

[sophia_iri]: https://crates.io/crates/sophia_iri

**edited**: make the second bullet optional, following @Tpt's [comment](https://github.com/w3c-cg/r2c2/pull/5#issuecomment-2732035761)