### PR TITLE
[statement_validation] rename traits to avoid ambiguity

### DIFF
--- a/statement_validation/src/_iri.rs
+++ b/statement_validation/src/_iri.rs
@@ -4,7 +4,7 @@ use r2c2_statement::Iri;
 use regex::Regex;
 
 /// Extension trait for [`Iri`] providing validation methods.
-pub trait IriValid<'a> {
+pub trait IriValidation<'a> {
     /// Return a new [`Iri`] if the argument is a valid IRI, otherwise None.
     #[allow(clippy::new_ret_no_self)]
     fn new(txt: impl Into<Cow<'a, str>>) -> Option<Iri<'a>>;
@@ -16,7 +16,7 @@ pub trait IriValid<'a> {
     fn debug_assert_is_valid(&self);
 }
 
-impl<'a> IriValid<'a> for Iri<'a> {
+impl<'a> IriValidation<'a> for Iri<'a> {
     fn new(txt: impl Into<Cow<'a, str>>) -> Option<Self> {
         let inner = txt.into();
         IRI_REGEX

--- a/statement_validation/src/_language_tag.rs
+++ b/statement_validation/src/_language_tag.rs
@@ -4,7 +4,7 @@ use r2c2_statement::LangTag;
 use regex::Regex;
 
 /// Extension trait for [`LangTag`] providing validation methods.
-pub trait LangTagValid<'a> {
+pub trait LangTagValidation<'a> {
     /// Return a new [`LangTag`] if the argument is a valid IRI, otherwise None.
     #[allow(clippy::new_ret_no_self)]
     fn new(txt: impl Into<Cow<'a, str>>) -> Option<LangTag<'a>>;
@@ -16,7 +16,7 @@ pub trait LangTagValid<'a> {
     fn debug_assert_is_valid(&self);
 }
 
-impl<'a> LangTagValid<'a> for LangTag<'a> {
+impl<'a> LangTagValidation<'a> for LangTag<'a> {
     fn new(txt: impl Into<Cow<'a, str>>) -> Option<Self> {
         let inner = txt.into();
         TAG_REGEX


### PR DESCRIPTION
as pointed out by @GordianDziwis, the name IriValid could be read as "valid IRI", implying that the trait Iri could yield invalid IRIs...

see https://github.com/w3c-cg/r2c2/pull/6#issuecomment-3015228637