### PR TITLE
[statement] fix various issues

### DIFF
--- a/statement/src/_literal.rs
+++ b/statement/src/_literal.rs
@@ -36,7 +36,7 @@ pub enum Literal<'a> {
 
 impl Literal<'_> {
     /// Borrow this [`Literal`] as another [`Literal`].
-    pub fn borrowed(&self) -> Literal {
+    pub fn borrowed(&self) -> Literal<'_> {
         match self {
             Literal::Typed(lex, iri) => Literal::Typed(Cow::from(lex.as_ref()), iri.borrowed()),
             Literal::LanguageString(lex, lang_tag, base_dir) => {
@@ -46,7 +46,7 @@ impl Literal<'_> {
     }
 
     /// [lexical form](https://www.w3.org/TR/rdf12-concepts/#dfn-lexical-form) of this literal
-    pub fn lexical_form(&self) -> Cow<str> {
+    pub fn lexical_form(&self) -> Cow<'_, str> {
         let ref_cow = match self {
             Literal::Typed(lex, ..) => lex,
             Literal::LanguageString(lex, ..) => lex,

--- a/statement/src/_literal/_language_tag.rs
+++ b/statement/src/_literal/_language_tag.rs
@@ -7,7 +7,7 @@ use std::borrow::Cow;
 /// (i.e. ISO 639 for 2-3 characters language tag, or ISO 15924 for the script)
 ///
 /// [BCP47]: https://datatracker.ietf.org/doc/bcp47/
-#[derive(Clone, Debug, Eq, Ord)]
+#[derive(Clone, Debug, Eq)]
 pub struct LangTag<'a>(Cow<'a, str>);
 
 impl<'a> LangTag<'a> {
@@ -106,6 +106,8 @@ impl std::fmt::Display for LangTag<'_> {
 
 #[cfg(test)]
 mod test {
+    use std::cmp::Ordering;
+
     use super::*;
 
     #[test]
@@ -140,6 +142,10 @@ mod test {
         assert_eq!(tag1, tag2);
         assert_eq!(tag1, "en-gb");
         assert!(tag1 <= tag2 && tag2 <= tag1);
+        assert_eq!(tag1.partial_cmp(&tag2), Some(Ordering::Equal));
+        assert_eq!(tag2.partial_cmp(&tag1), Some(Ordering::Equal));
+        assert_eq!(tag1.cmp(&tag2), Ordering::Equal);
+        assert_eq!(tag2.cmp(&tag1), Ordering::Equal);
         assert!("EN" < tag1 && tag1 < "EN-ZZ");
     }
 }

--- a/statement/src/_literal/_language_tag.rs
+++ b/statement/src/_literal/_language_tag.rs
@@ -76,13 +76,17 @@ impl std::cmp::PartialEq<LangTag<'_>> for &str {
     }
 }
 
+impl std::cmp::Ord for LangTag<'_> {
+    fn cmp(&self, other: &Self) -> std::cmp::Ordering {
+        self.0
+            .to_ascii_lowercase()
+            .cmp(&other.0.to_ascii_lowercase())
+    }
+}
+
 impl std::cmp::PartialOrd for LangTag<'_> {
     fn partial_cmp(&self, other: &Self) -> Option<std::cmp::Ordering> {
-        Some(
-            self.0
-                .to_ascii_lowercase()
-                .cmp(&other.0.to_ascii_lowercase()),
-        )
+        Some(self.cmp(other))
     }
 }
 

--- a/statement/src/impl_oxrdf.rs
+++ b/statement/src/impl_oxrdf.rs
@@ -5,7 +5,7 @@
 //! This module is developed as if [`oxrdf`] implemented RDF 1.2 completely and strictly,
 //! which is not entirely true:
 //! - [`oxrdf`] does not support base direction in literals, so it is not complete;
-//! - [`oxrdf`] with the [`rdf-star`] feature allows triple terms in the subject position, so it is not strict.
+//! - [`oxrdf`] with the `rdf-star` feature allows triple terms in the subject position, so it is not strict.
 //!
 //! This is handled by panic'ing when those situations are encountered.
 //!


### PR DESCRIPTION
this fixes a bug in `LangString`: `PartialOrd` was case insensitive, but `Ord` was not
(thanks to `clippy` for spotting that!)

this also fixes a number of linting issues